### PR TITLE
Rename hasContact to has_contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sensu-go-hasContact filter
+# sensu-go-has-contact-filter
 
 This project implements an event filter for Sensu Go to provide contact routing capabilities. The project is currently a work in progress and not guaranteed to work as intended.
 

--- a/lib/has_contact.js
+++ b/lib/has_contact.js
@@ -1,4 +1,4 @@
-function hasContact(event, contact) {
+function has_contact(event, contact) {
     var check_contacts = [];
     var entity_contacts = [];
 

--- a/test/filter_contact_dev.yml
+++ b/test/filter_contact_dev.yml
@@ -9,4 +9,4 @@ spec:
   runtime_assets:
     - has_contact
   expressions:
-    - hasContact(event, "dev")
+    - has_contact(event, "dev")

--- a/test/filter_contact_ops.yml
+++ b/test/filter_contact_ops.yml
@@ -9,4 +9,4 @@ spec:
   runtime_assets:
     - has_contact
   expressions:
-    - hasContact(event, "ops")
+    - has_contact(event, "ops")


### PR DESCRIPTION
This change set renames the `hasContact` function to `has_contact` consistency with the naming of built-in Sensu Go filters like `is_incident` and `not_silenced`.