### PR TITLE
add no_contacts function to support fallback case

### DIFF
--- a/lib/no_contacts.js
+++ b/lib/no_contacts.js
@@ -1,0 +1,10 @@
+function no_contacts(event) {
+    if (event.hasOwnProperty("check") && event.check.hasOwnProperty("labels") && event.check.labels.hasOwnProperty("contacts")) {
+        return false;
+    }
+    else if (event.hasOwnProperty("entity") && event.entity.hasOwnProperty("labels") && event.entity.labels.hasOwnProperty("contacts")) {
+        return false;
+    } else {
+        return true;
+    }
+}

--- a/spec/no_contacts_spec.js
+++ b/spec/no_contacts_spec.js
@@ -1,0 +1,57 @@
+describe("no_contacts", function() {
+    it("returns true when event has no labels", function() {
+        var event = {}
+
+        expect(no_contacts(event)).toBe(true);
+    });
+
+    it("returns true when event has only some of the expected labels", function() {
+        var event = {
+            check: {},
+            entity: {
+                labels: {}
+            }
+        };
+
+        expect(no_contacts(event)).toBe(true);
+    });
+
+    it("returns false when event has only entity contacts", function() {
+        var event = {
+            check: {},
+            entity: {
+                labels: {
+                    contacts: "foo,bar,baz"
+                }
+            }
+        };
+
+        expect(no_contacts(event)).toBe(false);
+    });
+
+    it("returns false when event has only check contacts", function() {
+        var event = {
+            check: {
+                labels: {
+                    contacts: "foo,bar,baz"
+                }
+            },
+            entity: {}
+        };
+
+        expect(no_contacts(event)).toBe(false);
+    });
+
+    it("returns true when check and entity labels are empty", function() {
+        var event = {
+            check: {
+                labels: {}
+            },
+            entity: {
+                labels: {}
+            }
+        };
+
+        expect(no_contacts(event)).toBe(true);
+    });
+});


### PR DESCRIPTION
In order to support the "default" or "fallback" contact concept from Sensu Enterprise, we need a function which stipulates essentially the inverse of `has_contact`, meaning that the function should return true if the event lacks contact labels.

This change set adds a `no_contacts` function to provide this capability.