### PR TITLE
disregard entity contacts when check contacts are present

### DIFF
--- a/lib/has_contact.js
+++ b/lib/has_contact.js
@@ -19,11 +19,12 @@ function has_contact(event, contact) {
     if (check_contacts.indexOf(contact) >= 0) {
         return true;
     }
-    //  allow the event if contact is present in entity contacts
-    else if (entity_contacts.indexOf(contact) >= 0) {
+
+    //  allow the event if there are no check contacts and contact is present in entity contacts
+    if (check_contacts.length == 0 && entity_contacts.indexOf(contact) >= 0) {
         return true;
-    // otherwise event is not allowed
-    } else {
-        return false;
     }
+
+    // otherwise event is not allowed
+    return false;
 }

--- a/spec/has_contact_spec.js
+++ b/spec/has_contact_spec.js
@@ -108,4 +108,22 @@ describe("has_contact", function() {
 
         expect(has_contact(event, contact)).toBe(true);
     });
+
+    it("returns false when check has contacts which do not match and entity contains contacts that do match", function() {
+        var contact = "qux"
+        var event = {
+            entity: {
+                labels: {
+                    contacts: `foo,${contact},bar`
+                }
+            },
+            check: {
+                labels: {
+                    contacts: "baz"
+                }
+            }
+        }
+
+        expect(has_contact(event, contact)).toBe(false);
+    });
 });


### PR DESCRIPTION
In the interest of mirroring Sensu Enterprise contact routing behavior, the entity contacts should be disregarded when check labels indicate one or more contacts. 