### PR TITLE
Treat empty strings as an empty set of contacts

### DIFF
--- a/lib/has_contact.js
+++ b/lib/has_contact.js
@@ -19,11 +19,12 @@ function has_contact(event, contact) {
     if (check_contacts.indexOf(contact) >= 0) {
         return true;
     }
-    //  allow the event if contact is present in entity contacts
-    else if (entity_contacts.indexOf(contact) >= 0) {
+
+    //  allow the event if there are no check contacts and contact is present in entity contacts
+    if (check_contacts.length == 0 && entity_contacts.indexOf(contact) >= 0) {
         return true;
-    // otherwise event is not allowed
-    } else {
-        return false;
     }
+
+    // otherwise event is not allowed
+    return false;
 }

--- a/lib/no_contacts.js
+++ b/lib/no_contacts.js
@@ -1,10 +1,22 @@
 function no_contacts(event) {
+    var check_contacts = [];
+    var entity_contacts = [];
+
     if (event.hasOwnProperty("check") && event.check.hasOwnProperty("labels") && event.check.labels.hasOwnProperty("contacts")) {
-        return false;
+        check_contacts = event.check.labels.contacts.split(",");
+        // filter out any elements which do not contain at least one non-whitespace character
+        check_contacts = check_contacts.filter(function(entry) { return /\S/.test(entry); });
     }
-    else if (event.hasOwnProperty("entity") && event.entity.hasOwnProperty("labels") && event.entity.labels.hasOwnProperty("contacts")) {
-        return false;
-    } else {
+
+    if (event.hasOwnProperty("entity") && event.entity.hasOwnProperty("labels") && event.entity.labels.hasOwnProperty("contacts")) {
+        entity_contacts = event.entity.labels.contacts.split(",");
+        // filter out any elements which do not contain at least one non-whitespace character
+        entity_contacts = entity_contacts.filter(function(entry) { return /\S/.test(entry); });
+    }
+
+    if (check_contacts.length == 0 && entity_contacts.length == 0) {
         return true;
+    } else {
+        return false;
     }
 }

--- a/spec/has_contact_spec.js
+++ b/spec/has_contact_spec.js
@@ -108,4 +108,22 @@ describe("has_contact", function() {
 
         expect(has_contact(event, contact)).toBe(true);
     });
+
+    it("returns false when check has contacts which do not match and entity contains contacts that do match", function() {
+        var contact = "qux"
+        var event = {
+            entity: {
+                labels: {
+                    contacts: `foo,${contact},bar`
+                }
+            },
+            check: {
+                labels: {
+                    contacts: "baz"
+                }
+            }
+        }
+
+        expect(has_contact(event, contact)).toBe(false);
+    });
 });

--- a/spec/no_contacts_spec.js
+++ b/spec/no_contacts_spec.js
@@ -54,4 +54,16 @@ describe("no_contacts", function() {
 
         expect(no_contacts(event)).toBe(true);
     });
+
+    it("returns true when labels are empty strings", function() {
+        var event = {
+            check: {
+                labels: {
+                    contacts: ""
+                }
+            }
+        }
+
+        expect(no_contacts(event)).toBe(true);
+    });
 });


### PR DESCRIPTION
This change ensures that the no_contact filter correctly handles cases where a contacts label has an empty string value.